### PR TITLE
2040 move arcade to subdomain

### DIFF
--- a/Raft-README.md
+++ b/Raft-README.md
@@ -1,7 +1,7 @@
 ### Info on Raft's modifications to ArcadeDb for the the SOCOM DF usecase.
 
 #### Access ArcadeDb on DF helm deployments at:
-- Studio: ~/api/v1/arcadedb/studio/#
+- Studio: /
 - API: ~/api/v1/arcadedb
 
 #### Demo data

--- a/server/src/main/java/com/arcadedb/server/http/HttpServer.java
+++ b/server/src/main/java/com/arcadedb/server/http/HttpServer.java
@@ -109,7 +109,7 @@ public class HttpServer implements ServerPlugin {
 
     routes.addPrefixPath("/ws", new WebSocketConnectionHandler(this, webSocketEventBus));
 
-    routes.addPrefixPath("/api/v1",//
+    routes.addPrefixPath("/api/v1/arcadedb",//
         basicRoutes//
             .post("/begin/{database}", new PostBeginHandler(this))//
             .post("/close/{database}", new PostCloseDatabaseHandler(this))// DEPRECATED

--- a/server/src/main/resources/static/index.html
+++ b/server/src/main/resources/static/index.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
 
     <!-- Set base path for static resources, otherwise they try to resolve to /api/v1/___ and 404 -->
-    <!-- <base href="/" /> -->
+    <base href="/" />
 
     <!--====== Title ======-->
     <title>ArcadeDB - The Next Generation Multi-Model DBMS</title>

--- a/server/src/main/resources/static/index.html
+++ b/server/src/main/resources/static/index.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
 
     <!-- Set base path for static resources, otherwise they try to resolve to /api/v1/___ and 404 -->
-    <base href="/api/v1/arcadedb/studio/" />
+    <!-- <base href="/" /> -->
 
     <!--====== Title ======-->
     <title>ArcadeDB - The Next Generation Multi-Model DBMS</title>
@@ -77,7 +77,7 @@
 
       <div class="row">
         <div class="col-12 text-center">
-          <img src="/api/v1/arcadedb/studio/images/arcadedb-logo-small.png" />
+          <img src="/images/arcadedb-logo-small.png" />
           <br /><br />
         </div>
       </div>
@@ -101,7 +101,7 @@
                 style="height: 85px; padding: 5px"
               >
                 <img
-                  src="/api/v1/arcadedb/studio/images/arcadedb-logo-mini.png"
+                  src="/images/arcadedb-logo-mini.png"
                   style="width: 100%"
                 />
               </li>

--- a/server/src/main/resources/static/js/studio-database.js
+++ b/server/src/main/resources/static/js/studio-database.js
@@ -76,7 +76,7 @@ async function logout() {
   localStorage.removeItem(REFRESH_TOKEN);
   localStorage.removeItem(ACCESS_TOKEN_EXPIRES);
   // redirect to login page
-  window.location.href = `${basePath}/studio`;
+  window.location.href = `${basePath}`;
 }
 
 function createInactivityTimer() {

--- a/server/src/main/resources/static/popup-login.html
+++ b/server/src/main/resources/static/popup-login.html
@@ -26,7 +26,7 @@
                   </div>
 
                   <button onclick="login()" class="btn btn-lg btn-primary btn-block" type="submit"> Sign in
-                    <img id="loginSpinner" class="ui-loading" src="/api/v1/arcadedb/studio/images/color-spin-small.svg" style="display: none;">
+                    <img id="loginSpinner" class="ui-loading" src="/images/color-spin-small.svg" style="display: none;">
                   </button>
                 </div>
               </div>

--- a/server/src/main/resources/static/query.html
+++ b/server/src/main/resources/static/query.html
@@ -16,7 +16,7 @@
       <textarea id="inputCommand" name="inputCommand"></textarea>
       <button class="btn btn-primary" onclick="executeCommand()" style="z-index: 100; position: absolute; top: 10px; right: 20px;">
         <i class="fa fa-play"></i>
-        <img id="executeSpinner" class="ui-loading" src="/api/v1/arcadedb/studio/images/color-spin-small.svg" style="display: none;">
+        <img id="executeSpinner" class="ui-loading" src="/images/color-spin-small.svg" style="display: none;">
       </button>
     </div>
 


### PR DESCRIPTION
## What does this PR do?
Revert the hardcoding of arcade static resource resolution to support new subdomain

## Motivation
^^

## Related issues
[#2040](https://github.com/raft-tech/data-fabric/issues/2040)

## Additional Notes
Test with Connor's upcoming related PR to simplify nginx routing and fix static resource requests being rewritten against the base path of arcade.

## Checklist

1. Build image locally
2. Run connor's branch of Df locally
3. Load arcade image into DF
4. update reference
5. confirm you can hit arcade https://arcadedb.localhost/
6. Confirm you can log in with keycloak admin credentials
