### PR TITLE
2289 enforce data classification tagging

### DIFF
--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -144,6 +144,19 @@
             <version>${graalvm.version}</version>
             <scope>runtime</scope>
         </dependency>
+
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <version>1.18.30</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>2.0.9</version>
+        </dependency>
+        
     </dependencies>
 
 </project>

--- a/engine/src/main/java/com/arcadedb/database/DocumentValidator.java
+++ b/engine/src/main/java/com/arcadedb/database/DocumentValidator.java
@@ -19,51 +19,34 @@
 package com.arcadedb.database;
 
 import com.arcadedb.exception.ValidationException;
-import com.arcadedb.log.LogManager;
 import com.arcadedb.schema.Property;
 import com.arcadedb.schema.Type;
 
-//import lombok.extern.slf4j.Slf4j;
-
 import java.math.*;
 import java.util.*;
-import java.util.logging.Level;
 
 /**
  * Validates documents against constraints defined in the schema.
  *
  * @author Luca Garulli (l.garulli@arcadedata.com)
  */
-//@Slf4j
 public class DocumentValidator {
 
-  public static void validateWithACCMutable(final MutableDocument document) throws ValidationException {
-    validate(document);
-
-    // additionally validate custom ACCM properties as embedded documents in the document
-    List<Property> properties = new ArrayList<>();
-    Property classification = new Property(document.getType(), "classification", Type.EMBEDDED);
-
-  }
+  // TODO move ACCM validation here?
 
   public static void validateSpecificProperties(final MutableDocument document, final List<Property> properties) throws ValidationException {
-    System.out.println("validating document: " + document.toString());
     document.checkForLazyLoadingProperties();
     for (Property entry : properties)
       validateField(document, entry);
   }
 
   public static void validate(final MutableDocument document) throws ValidationException {
-    System.out.println("validating document: " + document.toString());
     document.checkForLazyLoadingProperties();
     for (Property entry : document.getType().getProperties())
       validateField(document, entry);
   }
 
   public static void validateField(final MutableDocument document, final Property p) throws ValidationException {
-    LogManager.instance().log(DocumentValidator.class, Level.SEVERE, "Validting field with props: " + p.toString());
-   // log.info("Validating field {} with value {}", p, document.get(p.getName()));
-    System.out.println("Validating field " + p.toString() + " with value " + document.get(p.getName()));
     if (p.isMandatory() && !document.has(p.getName()))
       throwValidationException(p, "is mandatory, but not found on record: " + document);
 
@@ -324,6 +307,6 @@ public class DocumentValidator {
   }
 
   private static void throwValidationException(final Property p, final String message) throws ValidationException {
-    throw new ValidationException("The property '" + p.getName() + "' " + message, p);
+    throw new ValidationException("The property '" + p.getName() + "' " + message);
   }
 }

--- a/engine/src/main/java/com/arcadedb/database/DocumentValidator.java
+++ b/engine/src/main/java/com/arcadedb/database/DocumentValidator.java
@@ -19,25 +19,51 @@
 package com.arcadedb.database;
 
 import com.arcadedb.exception.ValidationException;
+import com.arcadedb.log.LogManager;
 import com.arcadedb.schema.Property;
 import com.arcadedb.schema.Type;
 
+//import lombok.extern.slf4j.Slf4j;
+
 import java.math.*;
 import java.util.*;
+import java.util.logging.Level;
 
 /**
  * Validates documents against constraints defined in the schema.
  *
  * @author Luca Garulli (l.garulli@arcadedata.com)
  */
+//@Slf4j
 public class DocumentValidator {
+
+  public static void validateWithACCMutable(final MutableDocument document) throws ValidationException {
+    validate(document);
+
+    // additionally validate custom ACCM properties as embedded documents in the document
+    List<Property> properties = new ArrayList<>();
+    Property classification = new Property(document.getType(), "classification", Type.EMBEDDED);
+
+  }
+
+  public static void validateSpecificProperties(final MutableDocument document, final List<Property> properties) throws ValidationException {
+    System.out.println("validating document: " + document.toString());
+    document.checkForLazyLoadingProperties();
+    for (Property entry : properties)
+      validateField(document, entry);
+  }
+
   public static void validate(final MutableDocument document) throws ValidationException {
+    System.out.println("validating document: " + document.toString());
     document.checkForLazyLoadingProperties();
     for (Property entry : document.getType().getProperties())
       validateField(document, entry);
   }
 
   public static void validateField(final MutableDocument document, final Property p) throws ValidationException {
+    LogManager.instance().log(DocumentValidator.class, Level.SEVERE, "Validting field with props: " + p.toString());
+   // log.info("Validating field {} with value {}", p, document.get(p.getName()));
+    System.out.println("Validating field " + p.toString() + " with value " + document.get(p.getName()));
     if (p.isMandatory() && !document.has(p.getName()))
       throwValidationException(p, "is mandatory, but not found on record: " + document);
 
@@ -298,6 +324,6 @@ public class DocumentValidator {
   }
 
   private static void throwValidationException(final Property p, final String message) throws ValidationException {
-    throw new ValidationException("The property '" + p.getName() + "' " + message);
+    throw new ValidationException("The property '" + p.getName() + "' " + message, p);
   }
 }

--- a/engine/src/main/java/com/arcadedb/database/EmbeddedDatabase.java
+++ b/engine/src/main/java/com/arcadedb/database/EmbeddedDatabase.java
@@ -784,7 +784,7 @@ public class EmbeddedDatabase extends RWLockContext implements DatabaseInternal 
     setDefaultValues(record);
 
     if (record instanceof MutableDocument)
-      ((MutableDocument) record).validate();
+      ((MutableDocument) record).validateAndAccmCheck();
 
     // INVOKE EVENT CALLBACKS
     if (!events.onBeforeCreate(record))
@@ -840,7 +840,7 @@ public class EmbeddedDatabase extends RWLockContext implements DatabaseInternal 
       throw new DatabaseIsReadOnlyException("Cannot update a record");
 
     if (record instanceof MutableDocument)
-      ((MutableDocument) record).validate();
+      ((MutableDocument) record).validateAndAccmCheck();
 
     // INVOKE EVENT CALLBACKS
     if (!events.onBeforeUpdate(record))

--- a/engine/src/main/java/com/arcadedb/database/MutableDocument.java
+++ b/engine/src/main/java/com/arcadedb/database/MutableDocument.java
@@ -145,12 +145,9 @@ public class MutableDocument extends BaseDocument implements RecordInternal {
     List<Property> properties = new ArrayList<>();
 
     for (AccmProperty accmProperty : accmProperties) {
-      System.out.println("property: " + accmProperty.toString());
-
       DocumentType parentType = database.getSchema().getType(accmProperty.parentType());
 
       if (parentType == null) {
-        System.out.println("Error parent type not found");
         continue;
       }
 
@@ -202,8 +199,6 @@ public class MutableDocument extends BaseDocument implements RecordInternal {
 
       set(CLASSIFICATION_MARKED, true);
     } catch (ValidationException e) {
-      // System.out.println("ValidationException: " + e.getMessage());
-
       // Only ignore data validation errors on writes for service accounts.
       if (database.getContext().getCurrentUser().isServiceAccount()) {
 

--- a/engine/src/main/java/com/arcadedb/engine/BucketIterator.java
+++ b/engine/src/main/java/com/arcadedb/engine/BucketIterator.java
@@ -145,8 +145,13 @@ public class BucketIterator implements Iterator<Record> {
   }
 
   private boolean checkPermissionsOnDocument(final Document document) {
-    if ((!document.has(MutableDocument.CLASSIFICATION_MARKED) || !document.getBoolean(MutableDocument.CLASSIFICATION_MARKED))
-          && !database.getContext().getCurrentUser().isDataSteward(document.getTypeName())) {
+    var currentUser = database.getContext().getCurrentUser();
+
+    if (currentUser.isServiceAccount() || currentUser.isDataSteward(document.getTypeName())) {
+      return true;
+    }
+
+    if ((!document.has(MutableDocument.CLASSIFICATION_MARKED) || !document.getBoolean(MutableDocument.CLASSIFICATION_MARKED))) {
       return false;
     }
     return true;

--- a/engine/src/main/java/com/arcadedb/engine/BucketIterator.java
+++ b/engine/src/main/java/com/arcadedb/engine/BucketIterator.java
@@ -75,7 +75,6 @@ public class BucketIterator implements Iterator<Record> {
     database.executeInReadLock(() -> {
       next = null;
       while (true) {
-        System.out.println("bucket iterator fetchNext()");
         if (currentPage == null) {
           if (nextPageNumber > totalPages) {
             return null;
@@ -147,7 +146,7 @@ public class BucketIterator implements Iterator<Record> {
 
   private boolean checkPermissionsOnDocument(final Document document) {
     if ((!document.has(MutableDocument.CLASSIFICATION_MARKED) || !document.getBoolean(MutableDocument.CLASSIFICATION_MARKED))
-          && !database.getContext().getCurrentUser().isDataSteward()) {
+          && !database.getContext().getCurrentUser().isDataSteward(document.getTypeName())) {
       return false;
     }
     return true;

--- a/engine/src/main/java/com/arcadedb/exception/ValidationException.java
+++ b/engine/src/main/java/com/arcadedb/exception/ValidationException.java
@@ -18,26 +18,15 @@
  */
 package com.arcadedb.exception;
 
-import com.arcadedb.schema.Property;
-
-import lombok.Getter;
-
 /**
  * Exception thrown when a constrain is violated.
  *
  * @author Luca Garulli (l.garulli@arcadedata.com)
  */
 public class ValidationException extends ArcadeDBException {
-  @Getter
-  Property property;
 
 public ValidationException(final String message) {
     super(message);
-  }
-
-  public ValidationException(final String message, Property property) {
-    super(message);
-    this.property = property;
   }
 
   public ValidationException(final String message, final Throwable cause) {

--- a/engine/src/main/java/com/arcadedb/exception/ValidationException.java
+++ b/engine/src/main/java/com/arcadedb/exception/ValidationException.java
@@ -18,14 +18,26 @@
  */
 package com.arcadedb.exception;
 
+import com.arcadedb.schema.Property;
+
+import lombok.Getter;
+
 /**
  * Exception thrown when a constrain is violated.
  *
  * @author Luca Garulli (l.garulli@arcadedata.com)
  */
 public class ValidationException extends ArcadeDBException {
-  public ValidationException(final String message) {
+  @Getter
+  Property property;
+
+public ValidationException(final String message) {
     super(message);
+  }
+
+  public ValidationException(final String message, Property property) {
+    super(message);
+    this.property = property;
   }
 
   public ValidationException(final String message, final Throwable cause) {

--- a/engine/src/main/java/com/arcadedb/schema/Property.java
+++ b/engine/src/main/java/com/arcadedb/schema/Property.java
@@ -27,9 +27,12 @@ import com.arcadedb.query.sql.parser.ParseException;
 import com.arcadedb.query.sql.parser.SqlParser;
 import com.arcadedb.serializer.json.JSONObject;
 
+import lombok.ToString;
+
 import java.io.*;
 import java.util.*;
 
+@ToString
 public class Property {
   private final        DocumentType        owner;
   private final        String              name;
@@ -74,6 +77,10 @@ public class Property {
    */
   public Index getOrCreateIndex(final EmbeddedSchema.INDEX_TYPE type, final boolean unique) {
     return owner.getSchema().buildTypeIndex(owner.getName(), new String[] { name }).withType(type).withUnique(unique).withIgnoreIfExists(true).create();
+  }
+
+  public DocumentType getOwner() {
+    return owner;
   }
 
   public String getName() {

--- a/engine/src/main/java/com/arcadedb/schema/Property.java
+++ b/engine/src/main/java/com/arcadedb/schema/Property.java
@@ -27,6 +27,7 @@ import com.arcadedb.query.sql.parser.ParseException;
 import com.arcadedb.query.sql.parser.SqlParser;
 import com.arcadedb.serializer.json.JSONObject;
 
+import lombok.Setter;
 import lombok.ToString;
 
 import java.io.*;
@@ -35,7 +36,9 @@ import java.util.*;
 @ToString
 public class Property {
   private final        DocumentType        owner;
-  private final        String              name;
+
+  @Setter
+  private              String              name;
   private final        Type                type;
   private final        int                 id;
   protected final      Map<String, Object> custom          = new HashMap<>();

--- a/engine/src/main/java/com/arcadedb/security/ACCM/AccmProperty.java
+++ b/engine/src/main/java/com/arcadedb/security/ACCM/AccmProperty.java
@@ -1,0 +1,29 @@
+package com.arcadedb.security.ACCM;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.arcadedb.schema.Type;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.experimental.Accessors;
+
+@Data
+@NoArgsConstructor
+@Accessors(chain = true, fluent = true)
+public class AccmProperty {
+
+    // Split name by periods into property path
+    private String name;
+    private String parentType;
+    private Type dataType;
+    private boolean required;
+    private boolean notNull;
+    private boolean readOnly;
+    private List<String> options = new ArrayList<>();
+    private String validationRegex;
+
+   // private String keycloakUserInfoPropertyName;
+   // might also be coming from roles
+}

--- a/engine/src/main/java/com/arcadedb/security/SecurityDatabaseUser.java
+++ b/engine/src/main/java/com/arcadedb/security/SecurityDatabaseUser.java
@@ -66,6 +66,8 @@ public interface SecurityDatabaseUser {
 
   boolean isDataSteward(String type);
 
+  boolean isServiceAccount();
+
   String getName();
 
   long getResultSetLimit();

--- a/engine/src/main/java/com/arcadedb/security/SecurityDatabaseUser.java
+++ b/engine/src/main/java/com/arcadedb/security/SecurityDatabaseUser.java
@@ -64,7 +64,7 @@ public interface SecurityDatabaseUser {
 
   boolean requestAccessOnFile(int fileId, ACCESS access);
 
-  boolean isDataSteward();
+  boolean isDataSteward(String type);
 
   String getName();
 

--- a/engine/src/main/java/com/arcadedb/security/SecurityDatabaseUser.java
+++ b/engine/src/main/java/com/arcadedb/security/SecurityDatabaseUser.java
@@ -64,6 +64,8 @@ public interface SecurityDatabaseUser {
 
   boolean requestAccessOnFile(int fileId, ACCESS access);
 
+  boolean isDataSteward();
+
   String getName();
 
   long getResultSetLimit();

--- a/server/src/main/java/com/arcadedb/server/security/ServerSecurity.java
+++ b/server/src/main/java/com/arcadedb/server/security/ServerSecurity.java
@@ -374,8 +374,7 @@ public class ServerSecurity implements ServerPlugin, com.arcadedb.security.Secur
     userJson.put("databases", databases);
 
     log.debug("getOrCreateUser userJson {}", userJson.toString());
-
-    final ServerSecurityUser serverSecurityUser = new ServerSecurityUser(server, userJson, arcadeRoles);
+    ServerSecurityUser serverSecurityUser = new ServerSecurityUser(server, userJson, arcadeRoles);
     users.put(username, serverSecurityUser);
 
     return serverSecurityUser;

--- a/server/src/main/java/com/arcadedb/server/security/ServerSecurity.java
+++ b/server/src/main/java/com/arcadedb/server/security/ServerSecurity.java
@@ -375,7 +375,7 @@ public class ServerSecurity implements ServerPlugin, com.arcadedb.security.Secur
 
     log.debug("getOrCreateUser userJson {}", userJson.toString());
 
-    final ServerSecurityUser serverSecurityUser = new ServerSecurityUser(server, userJson);
+    final ServerSecurityUser serverSecurityUser = new ServerSecurityUser(server, userJson, arcadeRoles);
     users.put(username, serverSecurityUser);
 
     return serverSecurityUser;

--- a/server/src/main/java/com/arcadedb/server/security/ServerSecurityDatabaseUser.java
+++ b/server/src/main/java/com/arcadedb/server/security/ServerSecurityDatabaseUser.java
@@ -25,6 +25,8 @@ import com.arcadedb.security.SecurityDatabaseUser;
 import com.arcadedb.security.SecurityManager;
 import com.arcadedb.serializer.json.JSONArray;
 import com.arcadedb.serializer.json.JSONObject;
+import com.arcadedb.server.security.oidc.ArcadeRole;
+import com.arcadedb.server.security.oidc.role.RoleType;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -41,11 +43,13 @@ public class ServerSecurityDatabaseUser implements SecurityDatabaseUser {
   private long resultSetLimit = -1;
   private long readTimeout = -1;
   private final boolean[] databaseAccessMap = new boolean[DATABASE_ACCESS.values().length];
+  private List<ArcadeRole> arcadeRoles = new ArrayList<>();
 
-  public ServerSecurityDatabaseUser(final String databaseName, final String userName, final String[] groups) {
+  public ServerSecurityDatabaseUser(final String databaseName, final String userName, final String[] groups, final List<ArcadeRole> arcadeRoles) {
     this.databaseName = databaseName;
     this.userName = userName;
     this.groups = groups;
+    this.arcadeRoles = arcadeRoles;
   }
 
   public String[] getGroups() {
@@ -301,9 +305,15 @@ public class ServerSecurityDatabaseUser implements SecurityDatabaseUser {
   }
 
   @Override
-  public boolean isDataSteward() {
+  public boolean isDataSteward(String type) {
+    // check if the user possess a data steward role for the given type
+
+    for (ArcadeRole role : arcadeRoles) {
+      if (role.getRoleType().equals(RoleType.DATA_STEWARD) && role.isTypeMatch(type)) {
+        return true;
+      }
+    }
+
     return false;
-    // TODO Auto-generated method stub
-    //throw new UnsupportedOperationException("Unimplemented method 'isDataSteward'");
   }
 }

--- a/server/src/main/java/com/arcadedb/server/security/ServerSecurityDatabaseUser.java
+++ b/server/src/main/java/com/arcadedb/server/security/ServerSecurityDatabaseUser.java
@@ -304,10 +304,11 @@ public class ServerSecurityDatabaseUser implements SecurityDatabaseUser {
     return array;
   }
 
+  /**
+   * Checks if the user is a data steward role type for type of object requested.
+   */
   @Override
   public boolean isDataSteward(String type) {
-    // check if the user possess a data steward role for the given type
-
     for (ArcadeRole role : arcadeRoles) {
       if (role.getRoleType().equals(RoleType.DATA_STEWARD) && role.isTypeMatch(type)) {
         return true;
@@ -319,6 +320,7 @@ public class ServerSecurityDatabaseUser implements SecurityDatabaseUser {
 
   @Override
   public boolean isServiceAccount() {
+    // Keycloak client service account naming convention follows this. Update as needed.
     return this.userName.startsWith("service-account-");
   }
 }

--- a/server/src/main/java/com/arcadedb/server/security/ServerSecurityDatabaseUser.java
+++ b/server/src/main/java/com/arcadedb/server/security/ServerSecurityDatabaseUser.java
@@ -316,4 +316,9 @@ public class ServerSecurityDatabaseUser implements SecurityDatabaseUser {
 
     return false;
   }
+
+  @Override
+  public boolean isServiceAccount() {
+    return this.userName.startsWith("service-account-");
+  }
 }

--- a/server/src/main/java/com/arcadedb/server/security/ServerSecurityDatabaseUser.java
+++ b/server/src/main/java/com/arcadedb/server/security/ServerSecurityDatabaseUser.java
@@ -299,4 +299,11 @@ public class ServerSecurityDatabaseUser implements SecurityDatabaseUser {
   //  log.debug("updateAccessArray: accessObj: {}; array: {}", access, array);
     return array;
   }
+
+  @Override
+  public boolean isDataSteward() {
+    return false;
+    // TODO Auto-generated method stub
+    //throw new UnsupportedOperationException("Unimplemented method 'isDataSteward'");
+  }
 }

--- a/server/src/main/java/com/arcadedb/server/security/oidc/ArcadeRole.java
+++ b/server/src/main/java/com/arcadedb/server/security/oidc/ArcadeRole.java
@@ -152,7 +152,6 @@ public class ArcadeRole {
             ArcadeRole arcadeRole = new ArcadeRole();
             arcadeRole.name = role;
             arcadeRole.roleType = arcadeRole.getRoleTypeFromString(role);
-            // log.info("role type: {}", arcadeRole.roleType);
 
             if (arcadeRole.roleType == null) {
                 return null;
@@ -286,8 +285,7 @@ public class ArcadeRole {
                 }
                 break;
             case DATA_STEWARD:
-                if (notNullOrEmpty(database) && notNullOrEmpty(tableRegex) && crudPermissions != null
-                        && !crudPermissions.isEmpty()) {
+                if (notNullOrEmpty(database) && notNullOrEmpty(tableRegex)) {
                     sb.append(DATABASE_MARKER);
                     sb.append(database);
                     sb.append(PERMISSION_DELIMITER);
@@ -309,11 +307,27 @@ public class ArcadeRole {
 
     /**
      * Checks if the provided table/type in the role matches the table/type of interest.
-     * TODO implement regex support.
+     * TODO implement regex support. Only wildcards are supported now.
      * @param type
      * @return
      */
     public boolean isTypeMatch(String type) {
+        if (this.tableRegex == null) {
+            return true;
+        }
         return this.tableRegex.equals(type) || this.tableRegex.equals(ALL_WILDCARD);
+    }
+
+    /**
+     * Chekcs if the granted database(s) in the role matches the database of interest.
+     * TODO implement regex support. Only wildcards are supported now.
+     * @param database
+     * @return
+     */
+    public boolean isDatabaseMatch(String database) {
+        if (this.database == null || database == null) {
+            return false;
+        }
+        return this.database.equalsIgnoreCase(database) || this.database.equals(ALL_WILDCARD);
     }
 }

--- a/server/src/main/java/com/arcadedb/server/security/oidc/role/RoleType.java
+++ b/server/src/main/java/com/arcadedb/server/security/oidc/role/RoleType.java
@@ -10,7 +10,8 @@ import lombok.Getter;
 public enum RoleType {
     DATABASE_ADMIN("dba", "dba"),
     USER("user", "user"),
-    SERVER_ADMIN("sa","sa");
+    SERVER_ADMIN("sa","sa"),
+    DATA_STEWARD("data_steward", "data_steward");
 
     /**
      * Keyword used in the keycloak role name to look for when knowing what type of role is being defined

--- a/server/src/main/java/com/arcadedb/server/security/oidc/role/RoleType.java
+++ b/server/src/main/java/com/arcadedb/server/security/oidc/role/RoleType.java
@@ -11,7 +11,7 @@ public enum RoleType {
     DATABASE_ADMIN("dba", "dba"),
     USER("user", "user"),
     SERVER_ADMIN("sa","sa"),
-    DATA_STEWARD("data-steward", "data-steward");
+    DATA_STEWARD("dataSteward", "dataSteward");
 
     /**
      * Keyword used in the keycloak role name to look for when knowing what type of role is being defined

--- a/server/src/main/java/com/arcadedb/server/security/oidc/role/RoleType.java
+++ b/server/src/main/java/com/arcadedb/server/security/oidc/role/RoleType.java
@@ -11,7 +11,7 @@ public enum RoleType {
     DATABASE_ADMIN("dba", "dba"),
     USER("user", "user"),
     SERVER_ADMIN("sa","sa"),
-    DATA_STEWARD("data_steward", "data_steward");
+    DATA_STEWARD("data-steward", "data-steward");
 
     /**
      * Keyword used in the keycloak role name to look for when knowing what type of role is being defined

--- a/server/src/main/resources/static/index.html
+++ b/server/src/main/resources/static/index.html
@@ -271,18 +271,12 @@
           $("#inputUserName").delay(1000).focus().select();
         });
 
-        console.log("aaa doc localstorage", localStorage.getItem(REFRESH_TOKEN), localStorage.getItem(ACCESS_TOKEN_EXPIRES));
-
         if (
           globalCredentials == null &&
           (localStorage.getItem(REFRESH_TOKEN) == null ||
             (localStorage.getItem(ACCESS_TOKEN_EXPIRES) &&
               localStorage.getItem(ACCESS_TOKEN_EXPIRES) < Date.now()))
         ) {
-          console.log("aa test", globalCredentials == null,
-            localStorage.getItem(REFRESH_TOKEN) == null,
-            localStorage.getItem(ACCESS_TOKEN_EXPIRES),
-            localStorage.getItem(ACCESS_TOKEN_EXPIRES) < Date.now());
           showLoginPopup();
         } else {
           console.log("index gc", globalCredentials);

--- a/server/src/main/resources/static/js/studio-database.js
+++ b/server/src/main/resources/static/js/studio-database.js
@@ -76,7 +76,7 @@ async function logout() {
   localStorage.removeItem(REFRESH_TOKEN);
   localStorage.removeItem(ACCESS_TOKEN_EXPIRES);
   // redirect to login page
-  window.location.href = `${basePath}`;
+  window.location.href = "/";
 }
 
 function createInactivityTimer() {


### PR DESCRIPTION
## What does this PR do?
Forces ordinary users to provide classification data with new writes, except for service accounts. Ordinary users won't have visibility of documents without proper classification markings, but users with the data steward role will be able to view and manage those documents without proper classification markings.

## Motivation
SOCOM data handling requirements

## Related issues
A list of issues either fixed, containing architectural discussions, otherwise relevant
for this Pull Request.

## Additional Notes
Anything else we should know when reviewing?

## Setup
1. Using the corresponding data fabric PR, spin up your local environment
https://github.com/raft-tech/data-fabric/pull/2334

2. From the root project, run

        docker buildx build --platform linux/arm64 --load -t raft-tech/arcadedev ./

3. Load into kind

        kind load docker-image raft-tech/arcadedev  --name data-fabric
        
4. Update image in arcade's stateful set
5. Kill the pod to force it to update if needed
6. Create a new keycloak user named "service-account-test". Assign to "Arcade Admin" group.
7. In keycloak, remove the Data Steward group from the admin user.

## Testing

1. Log into arcade http://arcadedb.localhost
2. Create a new database through the gui (click the database icon in the upper left, and look at the menu in the upper right)

3. Confirm you can switch to the new database in the database dropdown in the upper middle left of the screen

4. Run the following setup scripts individually

        CREATE VERTEX TYPE Customer

        CREATE DOCUMENT TYPE Classification IF NOT EXISTS

5. Run the following command, confirm it fails with a classification error

        INSERT INTO People CONTENT { firstName: 'Enzo', lastName: 'Ferrari' }

8. Run the following command, confirm it succeeds

        INSERT INTO People CONTENT { firstName: 'Enzo', lastName: 'Ferrari', classification: { @type: 'Classification', general: 'U' } }

9. Run the following command, confirm it fails with an invalid classification type error

        INSERT INTO People CONTENT { firstName: 'Enzo', lastName: 'Ferrari', classification: { @type: 'Classification', general: 'A' } }

10. Open a new session of arcade, and sign in as the "service-account-test' user.

11. Run the following command, confirm it succeeds

        INSERT INTO People CONTENT { firstName: 'Enzo2', lastName: 'Ferrari' }

12. Confirm the `classificationMarked` field is set to false. It may help to change the data display from graph to table or json.

13. Run the following command, confirm you can see both documents we created earlier, with 1 each of classification true or false.

        select from `People` limit 30

14. Open a new session of arcade, log in as admin user

15. Rerun the select command above. Confirm you only see a single document, the one with classification info and marked as true.

16. Sign out of arcade

17. In keycloak, add the admin user to the Data Steward Admin group.

18. Re-run the select command above, confirm you see both docs.