### PR TITLE
Fix unable to import datasets without classification markings, and au…

### DIFF
--- a/engine/src/main/java/com/arcadedb/database/DatabaseFactory.java
+++ b/engine/src/main/java/com/arcadedb/database/DatabaseFactory.java
@@ -41,6 +41,7 @@ public class DatabaseFactory implements AutoCloseable {
   private String classification = "U";
   private String owner;
   private boolean isPublic = false;
+  private boolean classificationValidationEnabled = true;
 
   public DatabaseFactory(final String path) {
     if (path == null || path.isEmpty())
@@ -95,6 +96,7 @@ public class DatabaseFactory implements AutoCloseable {
     database.getSchema().getEmbedded().setClassification(classification);
     database.getSchema().getEmbedded().setOwner(owner);
     database.getSchema().getEmbedded().setPublic(isPublic);
+    database.getSchema().getEmbedded().setClassificationValidationEnabled(classificationValidationEnabled);
     database.getSchema().getEmbedded().saveConfiguration();
 
     registerActiveInstance(database);
@@ -168,6 +170,11 @@ public class DatabaseFactory implements AutoCloseable {
   
   public DatabaseFactory setPublic(final boolean isPublic) {
     this.isPublic = isPublic;
+    return this;
+  }
+
+  public DatabaseFactory setClassificationValidationEnabled(boolean isClassificationValidationEnabled) {
+    this.classificationValidationEnabled = isClassificationValidationEnabled;
     return this;
   }
 }

--- a/engine/src/main/java/com/arcadedb/database/DocumentValidator.java
+++ b/engine/src/main/java/com/arcadedb/database/DocumentValidator.java
@@ -58,6 +58,12 @@ public class DocumentValidator {
 
   public static void validateClassificationMarkings(final MutableDocument document, 
           SecurityDatabaseUser securityDatabaseUser) {
+
+    // Skip validation checks if classification validation is disabled for the database
+    if (!document.getDatabase().getSchema().getEmbedded().isClassificationValidationEnabled()) {
+      return;
+    }
+
     boolean validSources = false;
 
     // validate sources, if present

--- a/engine/src/main/java/com/arcadedb/database/MutableDocument.java
+++ b/engine/src/main/java/com/arcadedb/database/MutableDocument.java
@@ -187,9 +187,10 @@ public class MutableDocument extends BaseDocument implements RecordInternal {
      * users until a data steward properly marks the document.
      */ 
     try {
-      DocumentValidator.validateClassificationMarkings(this, securityDatabaseUser);
-
-      set(CLASSIFICATION_MARKED, true);
+      if (this.getDatabase().getSchema().getEmbedded().isClassificationValidationEnabled()) {
+        DocumentValidator.validateClassificationMarkings(this, securityDatabaseUser);
+        set(CLASSIFICATION_MARKED, true);
+      }
     } catch (ValidationException e) {
       // Only ignore data validation errors on writes for service accounts.
       if (database.getContext().getCurrentUser().isServiceAccount()) {

--- a/engine/src/main/java/com/arcadedb/schema/EmbeddedSchema.java
+++ b/engine/src/main/java/com/arcadedb/schema/EmbeddedSchema.java
@@ -118,6 +118,12 @@ public class EmbeddedSchema implements Schema {
   @Getter
   private String createdDateTime;
 
+  @Getter @Setter
+  private boolean classificationValidationEnabled = true;
+
+  private final static String CLASSIFICATION_VALIDATION_SETTING = "classificationValidationEnabled";
+
+
   public EmbeddedSchema(final DatabaseInternal database, final String databasePath, final SecurityManager security) {
     this.database = database;
     this.databasePath = databasePath;
@@ -889,6 +895,10 @@ public class EmbeddedSchema implements Schema {
         createdDateTime = settings.getString("createdDateTime");
       }
 
+      if (settings.has(CLASSIFICATION_VALIDATION_SETTING)) {
+        classificationValidationEnabled = settings.getBoolean(CLASSIFICATION_VALIDATION_SETTING);
+      }
+
       dateFormat = settings.getString("dateFormat");
       dateTimeFormat = settings.getString("dateTimeFormat");
 
@@ -1133,6 +1143,8 @@ public class EmbeddedSchema implements Schema {
 
     settings.put("createdDateTime", LocalDateTime.now().toString());
     settings.put("createdBy", database.getCurrentUserName());
+
+    settings.put(CLASSIFICATION_VALIDATION_SETTING, classificationValidationEnabled);
 
     final JSONObject types = new JSONObject();
     root.put("types", types);

--- a/server/src/main/java/com/arcadedb/server/ArcadeDBServer.java
+++ b/server/src/main/java/com/arcadedb/server/ArcadeDBServer.java
@@ -40,6 +40,7 @@ import com.arcadedb.server.event.ServerEventLog;
 import com.arcadedb.server.ha.HAServer;
 import com.arcadedb.server.ha.ReplicatedDatabase;
 import com.arcadedb.server.http.HttpServer;
+import com.arcadedb.server.http.handler.PostServerCommandHandler;
 import com.arcadedb.server.monitor.DefaultServerMetrics;
 import com.arcadedb.server.monitor.ServerMetrics;
 import com.arcadedb.server.monitor.ServerMonitor;
@@ -153,6 +154,8 @@ public class ArcadeDBServer {
     // RELOAD DATABASE IF A PLUGIN REGISTERED A NEW DATABASE (LIKE THE GREMLIN SERVER)
     loadDatabases();
 
+    loadDefaultFoodDatabase();
+
     httpServer.startService();
 
     status = STATUS.ONLINE;
@@ -178,6 +181,36 @@ public class ArcadeDBServer {
     }
 
     serverMonitor.start();
+  }
+
+  private void loadDefaultFoodDatabase() {
+    if (getDatabaseNames() == null || !getDatabaseNames().contains("Food_Demo")) {
+      LogManager.instance().log(this, Level.INFO, "Food demo database not found, creating...");
+      Database database = createDatabase("Food_Demo", READ_WRITE, "U", "admin", true, false);
+
+      try {
+        InputStream inputStream = PostServerCommandHandler.class.getResourceAsStream("/importFoodDemoDatasetCommand.txt");
+        String data = readFromInputStream(inputStream);
+        database.command("sql", data);
+      } catch (Exception e) {
+        e.printStackTrace();
+        throw new ServerException("Error creating food demo dataset: " + e.getMessage());
+      }
+    } else {
+      LogManager.instance().log(this, Level.INFO, "Food demo database found, skipping...");
+    }
+  }
+
+  private String readFromInputStream(InputStream inputStream) throws IOException {
+    StringBuilder resultStringBuilder = new StringBuilder();
+    try (BufferedReader br
+      = new BufferedReader(new InputStreamReader(inputStream))) {
+        String line;
+        while ((line = br.readLine()) != null) {
+            resultStringBuilder.append(line).append("\n");
+        }
+    }
+    return resultStringBuilder.toString();
   }
 
   private void welcomeBanner() {
@@ -324,11 +357,11 @@ public class ArcadeDBServer {
   }
 
   public synchronized DatabaseInternal createDatabase(final String databaseName, final PaginatedFile.MODE mode) { 
-    return createDatabase(databaseName, mode, databaseName, null, false);
+    return createDatabase(databaseName, mode, databaseName, null, false, true);
   }
 
   public synchronized DatabaseInternal createDatabase(final String databaseName, final PaginatedFile.MODE mode,
-         String classification, String owner, boolean isPublic) {   DatabaseInternal db = databases.get(databaseName);
+         String classification, String owner, boolean isPublic, boolean isClassificationValidationEnabled) {   DatabaseInternal db = databases.get(databaseName);
     if (db != null)
       throw new IllegalArgumentException("Database '" + databaseName + "' already exists");
 
@@ -337,7 +370,8 @@ public class ArcadeDBServer {
         .setAutoTransaction(true)
         .setPublic(isPublic)
         .setClassification(classification)
-        .setOwner(owner);
+        .setOwner(owner)
+        .setClassificationValidationEnabled(isClassificationValidationEnabled);
     
     if (factory.exists())
       throw new IllegalArgumentException("Database '" + databaseName + "' already exists");

--- a/server/src/main/java/com/arcadedb/server/ArcadeDBServer.java
+++ b/server/src/main/java/com/arcadedb/server/ArcadeDBServer.java
@@ -193,7 +193,6 @@ public class ArcadeDBServer {
         String data = readFromInputStream(inputStream);
         database.command("sql", data);
       } catch (Exception e) {
-        e.printStackTrace();
         throw new ServerException("Error creating food demo dataset: " + e.getMessage());
       }
     } else {

--- a/server/src/main/java/com/arcadedb/server/http/handler/GetDatabasesInfoHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/GetDatabasesInfoHandler.java
@@ -46,6 +46,8 @@ public class GetDatabasesInfoHandler  extends AbstractHandler {
                   root.put("createdDateTime", embeddedSchema.getCreatedDateTime());
                 }
 
+                root.put("classificationValidationEnabled", embeddedSchema.isClassificationValidationEnabled());
+
                 databases.put(root);
             }
           }

--- a/server/src/main/java/com/arcadedb/server/http/handler/PostServerCommandHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/PostServerCommandHandler.java
@@ -50,8 +50,6 @@ import com.nimbusds.oauth2.sdk.util.StringUtils;
 import io.undertow.server.HttpServerExchange;
 
 import java.io.*;
-import java.nio.charset.StandardCharsets;
-import java.rmi.*;
 import java.util.*;
 
 public class PostServerCommandHandler extends AbstractHandler {
@@ -211,6 +209,7 @@ public class PostServerCommandHandler extends AbstractHandler {
       final String CLASSIFICATION = "classification";
       final String OWNER = "owner";
       final String VISIBILITY = "visibility";
+      final String CLASSIFICATION_VALIDATION_ENABLED = "classificationValidationEnabled";
 
       if (databaseName.isEmpty())
         throw new IllegalArgumentException("Database name empty");
@@ -245,10 +244,13 @@ public class PostServerCommandHandler extends AbstractHandler {
       String owner = options.has(OWNER) ? options.get(OWNER).getAsString() : null;
       boolean isPublic = options.has(VISIBILITY) ? options.get(VISIBILITY).getAsString().equalsIgnoreCase("public") : false;
 
+      boolean isClassificationValidationEnabled = options.has(CLASSIFICATION_VALIDATION_ENABLED)
+              ? options.get(CLASSIFICATION_VALIDATION_ENABLED).getAsBoolean() : true;
+
       final ArcadeDBServer server = httpServer.getServer();
       server.getServerMetrics().meter("http.create-database").hit();
 
-      final DatabaseInternal db = server.createDatabase(databaseName, PaginatedFile.MODE.READ_WRITE, classification, owner, isPublic);
+      final DatabaseInternal db = server.createDatabase(databaseName, PaginatedFile.MODE.READ_WRITE, classification, owner, isPublic, isClassificationValidationEnabled);
 
       if (server.getConfiguration().getValueAsBoolean(GlobalConfiguration.HA_ENABLED))
         ((ReplicatedDatabase) db).createInReplicas();
@@ -291,8 +293,8 @@ public class PostServerCommandHandler extends AbstractHandler {
             resultStringBuilder.append(line).append("\n");
         }
     }
-  return resultStringBuilder.toString();
-}
+    return resultStringBuilder.toString();
+  }
 
   private void createAndAssignRoleToUser(ArcadeRole arcadeRole, String username) {
     String newRole = arcadeRole.getKeycloakRoleName();

--- a/server/src/main/resources/importFoodDemoDatasetCommand.txt
+++ b/server/src/main/resources/importFoodDemoDatasetCommand.txt
@@ -1,0 +1,45 @@
+import database file://demo-data/FoodData_Central_foundation_food_json_2022-10-28.json with mapping = {
+     "FoundationFoods": [{
+         "@cat": "v",
+         "@type": "<foodClass>",
+         "foodNutrients": [{
+             "@cat": "e",
+             "@type": "HAS_NUTRIENT",
+             "@in": "nutrient",
+             "@cardinality": "no-duplicates",
+             "nutrient": {
+                 "@cat": "v",
+                 "@type": "Nutrient",
+                 "@id": "id",
+                 "@idType": "long",
+                 "@strategy": "merge"
+             },
+             "foodNutrientDerivation": "@ignore"
+         }],
+         "inputFoods": [{
+             "@cat": "e",
+             "@type": "INPUT",
+             "@in": "inputFood",
+             "@cardinality": "no-duplicates",
+             "inputFood": {
+                 "@cat": "v",
+                 "@type": "<foodClass>",
+                 "@id": "fdcId",
+                 "@idType": "long",
+                 "@strategy": "merge",
+                 "foodCategory": {
+                     "@cat": "e",
+                     "@type": "HAS_CATEGORY",
+                     "@cardinality": "no-duplicates",
+                     "@in": {
+                         "@cat": "v",
+                         "@type": "FoodCategory",
+                         "@id": "id",
+                         "@idType": "long",
+                         "@strategy": "merge"
+                     }
+                 }
+             }
+         }]
+     }]
+ }

--- a/server/src/main/resources/static/database.html
+++ b/server/src/main/resources/static/database.html
@@ -24,6 +24,7 @@
   <div class="row">
     <div class="col">
     <label><b>Classification: </b></label>&nbsp;<label id="lblClassification" name="lblClassification"></label><br>
+    <label><b>Classification Data Access Enforcement Enabled:</b></label>&nbsp;<label id="lblClassificationValidationEnabled" name="lblClassificationValidationEnabled"></label><br>
     <label><b>Owner: </b></label>&nbsp;<label id="lblOwner" name="lblOwner"></label><br>
     <label><b>Public: </b></label>&nbsp;<label id="lblPublic" name="lblPublic"></label><br>
     <!-- <label><b>Created By: </b></label>&nbsp;<label id="lblCreatedBy" name="lblCreatedBy"></label><br>

--- a/server/src/main/resources/static/js/studio-database.js
+++ b/server/src/main/resources/static/js/studio-database.js
@@ -266,7 +266,7 @@ function createDatabase(){
   <label for="rbPrivate">Private</label><br>
   <label for="import"><b>Import WIP SDL Ontology:</b></label>
   <input type="checkbox" id="chkImport" name="chkImport" value="import">
-  <label for="validation"><b>Enable SDL Classification Validation:</b></label>
+  <label for="validation"><b>Enable SDL Classification Data Access Enforcement:</b></label>
   <input type="checkbox" id="chkValidation" name="chkValidation" value="enabled" checked oninput=onValidationEnabledChange()>
   </div>
   `;
@@ -999,8 +999,9 @@ function updateDatabaseSetting(key, value){
 }
 
 function loadDatabaseMetadata(){
-  let data = getDatabaseMetadata();
-  setDatabaseMetadata(data);
+  getDatabaseMetadata().then((data) => {
+    setDatabaseMetadata(data)
+  });
 }
 
 async function getClassificationForDatabase(database) {
@@ -1033,12 +1034,13 @@ async function getDatabaseMetadata() {
 
 function setDatabaseMetadata(data) {
   for ( let i in data ) {
-    if ( data[i].name == $("#inputDatabase").val()) {
+    if ( data[i].name == escapeHtml($("#inputDatabase").val())) {
         $("#lblClassification").text( data[i].classification || "" );
         $("#lblOwner").text( data[i].owner || "" );
         $("#lblPublic").text( data[i].isPublic || "" );
         $("#lblCreatedBy").text( data[i].createdBy || "" );
         $("#lblCreatedDate").text( data[i].createdDateTime || "" );
+        $("#lblClassificationValidationEnabled").text( data[i].classificationValidationEnabled);
       }
     }
 }

--- a/server/src/main/resources/static/js/studio-database.js
+++ b/server/src/main/resources/static/js/studio-database.js
@@ -220,6 +220,10 @@ function updateDatabases( callback ){
         $("#inputDatabase").val(selected);
   
       $("#currentDatabase").html( getCurrentDatabase() );
+
+      getClassificationForDatabase(getCurrentDatabase()).then((classification) => {
+        $("#lblCurrentDatabaseClassification").html( classification );
+      });
     }
 
     $("#user").html(data.user);
@@ -247,7 +251,7 @@ function createDatabase(){
   let html = `
   <div style='text-align: left'>
   <div style="padding-bottom: 10px">
-  <b>Name:  </b><input id='inputCreateDatabaseName'></br>
+  <b>Name:  </b><input id='inputCreateDatabaseName' type='text'></br>
   </div>
   <div style="padding-bottom: 10px">
   <b>Classification:  </b><input id='inputClassification'></br>
@@ -262,8 +266,9 @@ function createDatabase(){
   <label for="rbPrivate">Private</label><br>
   <label for="import"><b>Import WIP SDL Ontology:</b></label>
   <input type="checkbox" id="chkImport" name="chkImport" value="import">
+  <label for="validation"><b>Enable SDL Classification Validation:</b></label>
+  <input type="checkbox" id="chkValidation" name="chkValidation" value="enabled" checked oninput=onValidationEnabledChange()>
   </div>
-
   `;
   Swal.fire({
     title: 'Create a new database',
@@ -293,15 +298,16 @@ function createDatabase(){
       var chkImport = document.getElementsByName('chkImport');
       let importOntology = chkImport[0].checked;
 
-      console.log("checked", chkImport, importOntology);
+      var chkValidation = document.getElementsByName('chkValidation');
+      let enableClassificationValidation = chkValidation[0].checked;
 
       var options = {
         owner: owner,
         visibility: visibility,
         classification: classification,
-        importOntology: importOntology
+        importOntology: importOntology,
+        classificationValidationEnabled: enableClassificationValidation
       }
-      console.log("options: ", database, owner, visibility, classification);
 
       if ( database == "" ){
         globalNotify( "Error", "Database name empty", "danger");
@@ -329,6 +335,21 @@ function createDatabase(){
   });
 
   $("#inputCreateDatabaseName").focus();
+}
+
+/**
+ * Set the database classification to U, and block updates when classification validation is disabled.
+ */
+function onValidationEnabledChange() {
+  var chkValidation = document.getElementsByName('chkValidation');
+  let enableClassificationValidation = chkValidation[0].checked;
+
+  if (!enableClassificationValidation) {
+    $("#inputClassification").val('U');
+    $("#inputClassification")[0].readOnly = true;
+  } else {
+    $("#inputClassification")[0].readOnly = false;
+  }
 }
 
 function dropDatabase(){
@@ -454,7 +475,16 @@ function getCurrentDatabase(){
   return db != null ? db.trim() : null;
 }
 
-function setCurrentDatabase( dbName ){
+function setCurrentDatabase( dbName ) {
+  let data = getDatabaseMetadata().then((data) => {
+
+    for ( let i in data ) {
+      if ( data[i].name == $("#inputDatabase").val()) {
+        $("#lblCurrentDatabaseClassification").html( escapeHtml(data[i].classification || "") );
+      }
+    }
+  });
+
   $("#currentDatabase").html( dbName );
   $("#inputDatabase").val( dbName );
   globalStorageSave("database.current", dbName);
@@ -502,7 +532,7 @@ function copyQueryFromHistory(){
     let queryHistory = getQueryHistory();
     let q = queryHistory[index];
     if( q != null ) {
-      setCurrentDatabase( q.d );
+       setCurrentDatabase( q.d );
        $("#inputLanguage").val( q.l );
       editor.setValue( q.c );
     }
@@ -968,31 +998,47 @@ function updateDatabaseSetting(key, value){
   });
 }
 
-function loadDatabaseMetadata() {
-  jQuery.ajax({
-    type: "GET",
-    url: basePath + "/databasesInfo",
-    beforeSend: function (xhr){
-      xhr.setRequestHeader('Authorization', globalCredentials);
-    }
-  })
-  .done(function(data) {
-    let json = JSON.parse(JSON.stringify(data));
-    
-    if (typeof json == "object" && json["result"] == 'ok') {
-      // no data returned, the user doesn't have access to any databases
-    } else {
-      // valid response, parse the databases the user has access to
-      let databases = "";
-      for ( let i in data.result ) {
-        if ( data.result[i].name == $("#inputDatabase").val()) {
-            $("#lblClassification").text( data.result[i].classification || "" );
-            $("#lblOwner").text( data.result[i].owner || "" );
-            $("#lblPublic").text( data.result[i].isPublic || "" );
-            $("#lblCreatedBy").text( data.result[i].createdBy || "" );
-            $("#lblCreatedDate").text( data.result[i].createdDateTime || "" );
-          }
-        }
+function loadDatabaseMetadata(){
+  let data = getDatabaseMetadata();
+  setDatabaseMetadata(data);
+}
+
+async function getClassificationForDatabase(database) {
+  database = escapeHtml(database?.trim());
+  if (database != null && database != "") {
+    let data = await getDatabaseMetadata();
+    for ( let i in data ) {
+      if ( data[i].name == escapeHtml(database)) {
+        return data[i].classification || "";
       }
-    });
+    }
+  }
+  return "";
+}
+
+async function getDatabaseMetadata() {
+
+  const dataResponse = await fetch(`${basePath}/databasesInfo`, {
+    method: "GET",
+    headers: {
+      "Content-Type": "application/json",
+      'Authorization': globalCredentials
+    }
+  });
+  if (dataResponse.ok) {
+    const data = await dataResponse.json();
+    return data.result;
+  }
+}
+
+function setDatabaseMetadata(data) {
+  for ( let i in data ) {
+    if ( data[i].name == $("#inputDatabase").val()) {
+        $("#lblClassification").text( data[i].classification || "" );
+        $("#lblOwner").text( data[i].owner || "" );
+        $("#lblPublic").text( data[i].isPublic || "" );
+        $("#lblCreatedBy").text( data[i].createdBy || "" );
+        $("#lblCreatedDate").text( data[i].createdDateTime || "" );
+      }
+    }
 }

--- a/server/src/main/resources/static/query.html
+++ b/server/src/main/resources/static/query.html
@@ -31,7 +31,7 @@
     <div class="col-1">
     </div>
     <div class="col-6 text-left">
-      <label>Current database:&nbsp;<a href="#" onclick="globalActivateTab('tab-database');" class="link"><span id="currentDatabase"></span></a></label>
+      <label>Current database:&nbsp;<a href="#" onclick="globalActivateTab('tab-database');" class="link">(<span id="lblCurrentDatabaseClassification"></span>)&nbsp;<span id="currentDatabase"></span></a></label>
     </div>
     <div class="col-2 text-left">
       <label>Auto Limit &nbsp;
@@ -302,7 +302,7 @@ function initQuery() {
   // APPLY SETTINGS FROM URL
   var dbPar = getURLParameter("db");
   if( dbPar != null && dbPar != "null")
-    setCurrentDatabase( dbPar );
+   setCurrentDatabase( dbPar );
 
   var limitPar = getURLParameter("limit");
   if( limitPar != null && limitPar != "null") {


### PR DESCRIPTION
…to import food demo dataset

## What does this PR do?
1. Adds new toggle to the create database screen in the Arcade GUI to enable classification markings validation
2. If the toggle is unchecked, the classification field is auto populated to Unclass, and set to read only to prevent users from attempting to put classified data into a marked database without validation or data access enforcement.
3. Auto import the included Food Demo dataset in arcade
4. Fixed the current database classification marking not showing on the query screen

## Motivation
Supporting demos

## Related issues
Closes #2477
Relates to #2481

## Additional Notes
This needs to be tested with the related DF PR: https://github.com/raft-tech/data-fabric/pull/2482

## Setup
1. Switch to DF PR branch locally https://github.com/raft-tech/data-fabric/pull/2482

2. Deploy DF

```
./hacks/df_create_kind.sh
export GHP_USERNAME=your_github_username_goes_here
export GHP_SECRET=your_github_pat_goes_here
./hacks/df_deploy.sh
```

3. Build arcade locally

```
 docker buildx build --platform linux/arm64 --load -t raft-tech/arcadedev ./
```

4. load into kind

```
 kind load docker-image raft-tech/arcadedev  --name data-fabric
```

5. Update image in arcade's replicaset

6. Kill the pod to force it to update if needed

7. Check the logs for arcade, you ought to see a log output like this

```
│ 2023-11-14 13:53:00.013 INFO  [ArcadeDBServer] <ArcadeDB_0> Food demo database not found, creating...                                                                                                      │
│ 2023-11-14 13:53:00.247 INFO  [SourceDiscovery] <ArcadeDB_0> Analyzing url: file://demo-data/FoodData_Central_foundation_food_json_2022-10-28.json...                                                      │
│ Parsed 46,067 (9,213/sec 81%) 0 records (0/sec) 3,038 vertices (607/sec) 14,639 edges (2,927/sec 0 skipped) 0 linked edges (0/sec 0%) updated documents 0 (0%)                                             │
│ Parsed 56,724 (10,497/sec 100%) 0 records (0/sec) 3,628 vertices (581/sec) 17,894 edges (3,207/sec 0 skipped) 0 linked edges (0/sec 0%) updated documents 0 (0%)
```

8. Log into the arcade GUI http://arcadedb.localhost/

9. Confirm the food demo dataset is available. It is probably already selected

10. Confirm the following query succeeds and returns graph data.

```
select *, bothE() as `@edges` from `Composite` limit 30
```