### PR TITLE
Add Arcade API to backup all databases to MinIO

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,7 +56,8 @@ EXPOSE 2480
 EXPOSE 2424
 
 # Gremlin Server (Apache TinkerPop)
-EXPOSE 8182
+# Commented out for now, the gremlin server bypasses most of the data access enforcements that have been added
+# EXPOSE 8182
 
 # Postgres protocol
 EXPOSE 5432

--- a/engine/src/main/java/com/arcadedb/schema/EmbeddedSchema.java
+++ b/engine/src/main/java/com/arcadedb/schema/EmbeddedSchema.java
@@ -1315,4 +1315,8 @@ public class EmbeddedSchema implements Schema {
 
     bucketId2TypeMap = newBucketId2TypeMap;
   }
+
+  public boolean shouldBackup() {
+      return true;
+  }
 }

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -108,6 +108,11 @@
             <version>${slf4j.version}</version>
         </dependency>
         <dependency>
+            <groupId>io.minio</groupId>
+            <artifactId>minio</artifactId>
+            <version>8.5.7</version>
+        </dependency>
+        <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
             <version>1.18.24</version>

--- a/server/src/main/java/com/arcadedb/server/DataFabricRestClient.java
+++ b/server/src/main/java/com/arcadedb/server/DataFabricRestClient.java
@@ -1,0 +1,172 @@
+package com.arcadedb.server;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URLEncoder;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.HashMap;
+import java.util.Map;
+
+import com.arcadedb.GlobalConfiguration;
+import com.arcadedb.serializer.json.JSONObject;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class DataFabricRestClient {
+    /**
+     * Gets the non admin base url for keycloak. Suitable for login operations
+     * 
+     * @return
+     */
+    protected static String getBaseKeycloakUrl() {
+        return String.format("%s/auth/realms/data-fabric", GlobalConfiguration.KEYCLOAK_ROOT_URL.getValueAsString());
+    }
+
+    /**
+     * Gets the admin base url for keycloak. Suitable for admin operations like
+     * getting user roles, creating roles, etc.
+     * 
+     * @return
+     */
+    protected static String getBaseKeycloakAdminUrl() {
+        return String.format("%s/auth/admin/realms/data-fabric",
+                GlobalConfiguration.KEYCLOAK_ROOT_URL.getValueAsString());
+    }
+
+    protected static String getLoginUrl() {
+        return getBaseKeycloakUrl() + "/protocol/openid-connect/token";
+    }
+
+    protected static String login(String username, String password) {
+        // TODO replace with keycloak config, or use keycloak login GUI
+        Map<String, String> formData = new HashMap<>();
+        formData.put("username", username);
+        formData.put("password", password);
+        formData.put("grant_type", "password");
+        formData.put("scope", "openid");
+        formData.put("client_id", GlobalConfiguration.KEYCLOAK_CLIENT_ID.getValueAsString());
+        formData.put("client_secret", System.getenv("KEYCLOAK_CLIENT_SECRET"));
+        return postUnauthenticatedAndGetResponse(getLoginUrl(), formData);
+    }
+
+    protected static String loginAndGetEncodedAccessString() {
+        var login = login("admin", System.getenv("KEYCLOAK_ADMIN_PASSWORD"));
+
+        JSONObject tokenJO = new JSONObject(login);
+        return tokenJO.getString("access_token");
+    }
+
+    public static String getAccessTokenJsonFromResponse(String token) {
+        if (token != null) {
+            JSONObject tokenJO = new JSONObject(token);
+            String accessTokenString = tokenJO.getString("access_token");
+            String encodedString = accessTokenString.substring(accessTokenString.indexOf(".") + 1,
+                    accessTokenString.lastIndexOf("."));
+            byte[] decodedBytes = Base64.getDecoder().decode(encodedString);
+            String decodedString = new String(decodedBytes);
+            log.debug("getAccessTokenFromResponse {}", decodedString);
+
+            return decodedString;
+        }
+
+        return null;
+    }
+
+    protected static String postUnauthenticatedAndGetResponse(String url, Map<String, String> formData) {
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create(url))
+                .POST(HttpRequest.BodyPublishers.ofString(getFormDataAsString(formData)))
+                .header("Content-Type", "application/x-www-form-urlencoded")
+                .build();
+
+        return sendAndGetResponse(request);
+    }
+
+    protected static String postAuthenticatedAndGetResponse(String url, String jsonPayload) {
+        String accessTokenString = loginAndGetEncodedAccessString();
+
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create(url))
+                .POST(HttpRequest.BodyPublishers.ofString(jsonPayload))
+                .header("Content-Type", "application/json")
+                .header("Authorization", "Bearer " + accessTokenString)
+                .build();
+
+        return sendAndGetResponse(request);
+    }
+
+        protected static String putAuthenticatedAndGetResponse(String url, String jsonPayload) {
+        String accessTokenString = loginAndGetEncodedAccessString();
+
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create(url))
+                .PUT(HttpRequest.BodyPublishers.ofString(jsonPayload))
+                .header("Content-Type", "application/json")
+                .header("Authorization", "Bearer " + accessTokenString)
+                .build();
+
+        return sendAndGetResponse(request);
+    }
+
+    protected static String sendAndGetResponse(HttpRequest request) {
+        HttpClient client = HttpClient.newHttpClient();
+        try {
+            HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+
+            if (response.statusCode() == 200) {
+                return response.body();
+            }
+        } catch (IOException | InterruptedException e) {
+            log.error("sendAndGetResponse()", e.getMessage());
+            log.debug("Exception", e);
+            return null;
+        }
+
+        return null;
+    }
+
+    protected static String sendAuthenticatedGetAndGetResponse(String url) {
+        String accessTokenString = loginAndGetEncodedAccessString();
+
+        // get user info
+        // "http://localhost/auth/admin/realms/data-fabric/users";
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create(url))
+                .GET()
+                .header("Authorization", "Bearer " + accessTokenString)
+                .build();
+
+        HttpClient client = HttpClient.newHttpClient();
+        try {
+            HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+
+            if (response.statusCode() == 200) {
+                return response.body();
+            }
+        } catch (IOException | InterruptedException e) {
+            log.error("sendAuthenticatedGetAndGetResponse()", e.getMessage());
+            log.debug("Exception", e);
+            return null;
+        }
+
+        return null;
+    }
+
+    public static String getFormDataAsString(Map<String, String> formData) {
+        StringBuilder formBodyBuilder = new StringBuilder();
+        for (Map.Entry<String, String> singleEntry : formData.entrySet()) {
+            if (formBodyBuilder.length() > 0) {
+                formBodyBuilder.append("&");
+            }
+            formBodyBuilder.append(URLEncoder.encode(singleEntry.getKey(), StandardCharsets.UTF_8));
+            formBodyBuilder.append("=");
+            formBodyBuilder.append(URLEncoder.encode(singleEntry.getValue(), StandardCharsets.UTF_8));
+        }
+        return formBodyBuilder.toString();
+    }
+}

--- a/server/src/main/java/com/arcadedb/server/MinioRestClient.java
+++ b/server/src/main/java/com/arcadedb/server/MinioRestClient.java
@@ -11,15 +11,21 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class MinioRestClient extends DataFabricRestClient {
 
-    private static final String minioUrl = System.getenv("INTERNAL_MINIO_URL");
+    private static final String minioUrl = "http://df-minio:9000"; //System.getenv("INTERNAL_MINIO_URL");
     private static final String bucketName =  System.getenv("BACKUP_BUCKET_NAME");
     private static final String rootArcadePath =  System.getenv("BACKUP_PATH");
 
     private static MinioClient getMinioClient() {
+        try {
         return MinioClient.builder()
                 .endpoint(minioUrl)
                 .credentials(System.getenv("INTERNAL_MINIO_USERNAME"), System.getenv("INTERNAL_MINIO_PASSWORD"))
                 .build();
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+
+        return null;
     }
 
     public static String getPreSignedUrl(String backupName, int expiryHours) {

--- a/server/src/main/java/com/arcadedb/server/MinioRestClient.java
+++ b/server/src/main/java/com/arcadedb/server/MinioRestClient.java
@@ -12,24 +12,26 @@ import lombok.extern.slf4j.Slf4j;
 public class MinioRestClient extends DataFabricRestClient {
 
     private static final String minioUrl = System.getenv("INTERNAL_MINIO_URL");
-    private static final String bucketName =  System.getenv("BACKUP_BUCKET_NAME");
-    private static final String rootArcadePath =  System.getenv("BACKUP_PATH");
+    private static final String bucketName = System.getenv("BACKUP_BUCKET_NAME");
+    private static final String rootArcadePath = System.getenv("BACKUP_PATH");
 
     private static MinioClient getMinioClient() {
         try {
-        return MinioClient.builder()
-                .endpoint(minioUrl)
-                .credentials(System.getenv("INTERNAL_MINIO_USERNAME"), System.getenv("INTERNAL_MINIO_PASSWORD"))
-                .build();
+            return MinioClient.builder()
+                    .endpoint(minioUrl)
+                    .credentials(System.getenv("INTERNAL_MINIO_USERNAME"), System.getenv("INTERNAL_MINIO_PASSWORD"))
+                    .build();
         } catch (Exception e) {
-            e.printStackTrace();
+            log.error("Error building minio client", e.getMessage());
+            log.debug("Exception", e);
         }
 
         return null;
     }
 
-    /** 
-     * Creates a presigned url to upload a given file name for a expirating period of time.
+    /**
+     * Creates a presigned url to upload a given file name for a expirating period
+     * of time.
      */
     public static String getPreSignedUrl(String backupName, int expiryHours) {
 
@@ -54,7 +56,7 @@ public class MinioRestClient extends DataFabricRestClient {
             getMinioClient().uploadObject(
                     UploadObjectArgs.builder()
                             .bucket(bucketName)
-                            .object(String.format("%s/%s/%s",rootArcadePath, databaseName, backupName))
+                            .object(String.format("%s/%s/%s", rootArcadePath, databaseName, backupName))
                             .filename(String.format("backups/%s/%s", databaseName, backupName))
                             .build());
         } catch (Exception e) {

--- a/server/src/main/java/com/arcadedb/server/MinioRestClient.java
+++ b/server/src/main/java/com/arcadedb/server/MinioRestClient.java
@@ -1,0 +1,56 @@
+package com.arcadedb.server;
+
+import java.util.concurrent.TimeUnit;
+
+import io.minio.GetPresignedObjectUrlArgs;
+import io.minio.MinioClient;
+import io.minio.UploadObjectArgs;
+import io.minio.http.Method;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class MinioRestClient extends DataFabricRestClient {
+
+    private static final String minioUrl = System.getenv("INTERNAL_MINIO_URL");
+    private static final String bucketName =  System.getenv("BACKUP_BUCKET_NAME");
+    private static final String rootArcadePath =  System.getenv("BACKUP_PATH");
+
+    private static MinioClient getMinioClient() {
+        return MinioClient.builder()
+                .endpoint(minioUrl)
+                .credentials(System.getenv("INTERNAL_MINIO_USERNAME"), System.getenv("INTERNAL_MINIO_PASSWORD"))
+                .build();
+    }
+
+    public static String getPreSignedUrl(String backupName, int expiryHours) {
+
+        try {
+            String url = getMinioClient().getPresignedObjectUrl(
+                    GetPresignedObjectUrlArgs.builder()
+                            .method(Method.PUT)
+                            .bucket(bucketName)
+                            .object(backupName)
+                            .expiry(expiryHours, TimeUnit.HOURS)
+                            .build());
+            return url;
+        } catch (Exception e) {
+            log.error("Error creating presigned url", e.getMessage());
+            log.debug("Exception", e);
+        }
+        return null;
+    }
+
+    public static void uploadBackup(String databaseName, String backupName) {
+        try {
+            getMinioClient().uploadObject(
+                    UploadObjectArgs.builder()
+                            .bucket(bucketName)
+                            .object(String.format("%s/%s/%s",rootArcadePath, databaseName, backupName))
+                            .filename(String.format("backups/%s/%s", databaseName, backupName))
+                            .build());
+        } catch (Exception e) {
+            log.error("Error uploading backup ", e.getMessage());
+            log.debug("Exception", e);
+        }
+    }
+}

--- a/server/src/main/java/com/arcadedb/server/MinioRestClient.java
+++ b/server/src/main/java/com/arcadedb/server/MinioRestClient.java
@@ -11,7 +11,7 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class MinioRestClient extends DataFabricRestClient {
 
-    private static final String minioUrl = "http://df-minio:9000"; //System.getenv("INTERNAL_MINIO_URL");
+    private static final String minioUrl = System.getenv("INTERNAL_MINIO_URL");
     private static final String bucketName =  System.getenv("BACKUP_BUCKET_NAME");
     private static final String rootArcadePath =  System.getenv("BACKUP_PATH");
 
@@ -28,6 +28,9 @@ public class MinioRestClient extends DataFabricRestClient {
         return null;
     }
 
+    /** 
+     * Creates a presigned url to upload a given file name for a expirating period of time.
+     */
     public static String getPreSignedUrl(String backupName, int expiryHours) {
 
         try {

--- a/server/src/main/java/com/arcadedb/server/http/HttpServer.java
+++ b/server/src/main/java/com/arcadedb/server/http/HttpServer.java
@@ -32,10 +32,12 @@ import com.arcadedb.server.http.ssl.TlsProtocol;
 import com.arcadedb.server.http.ws.WebSocketConnectionHandler;
 import com.arcadedb.server.http.ws.WebSocketEventBus;
 import com.arcadedb.server.security.ServerSecurityException;
+
 import io.undertow.Handlers;
 import io.undertow.Undertow;
 import io.undertow.server.RoutingHandler;
 import io.undertow.server.handlers.PathHandler;
+
 import org.xnio.Options;
 
 import javax.net.ssl.KeyManager;
@@ -133,6 +135,7 @@ public class HttpServer implements ServerPlugin {
             .get("/ready", new GetReadyHandler(this))
             .post("/login", new PostLoginHandler(this))
             .post("/refreshToken", new PostRefreshTokenHandler(this))
+            .post("/backup", new PostBackupHandler(this))
     );
 
     if (!"production".equals(GlobalConfiguration.SERVER_MODE.getValueAsString())) {

--- a/server/src/main/java/com/arcadedb/server/http/handler/PostBackupHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/PostBackupHandler.java
@@ -1,0 +1,147 @@
+package com.arcadedb.server.http.handler;
+
+import java.io.IOException;
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.List;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.network.binary.ServerIsNotTheLeaderException;
+import com.arcadedb.server.MinioRestClient;
+import com.arcadedb.server.ha.HAServer;
+import com.arcadedb.server.http.HttpServer;
+import com.arcadedb.server.security.ServerSecurityUser;
+import com.arcadedb.server.security.oidc.role.ServerAdminRole;
+
+import io.undertow.io.IoCallback;
+import io.undertow.io.Sender;
+import io.undertow.server.HttpServerExchange;
+import io.undertow.util.Headers;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Backup all databases (with backups enabled) to minio
+ */
+@Slf4j
+public class PostBackupHandler extends AbstractHandler {
+
+    public PostBackupHandler(final HttpServer httpServer) {
+        super(httpServer);
+    }
+
+    private void sendEvent(final HttpServerExchange exchange, String message) {
+        exchange.getResponseSender().send(message + "\n\n", new IoCallback() {
+            @Override
+            public void onComplete(HttpServerExchange exchange, Sender sender) {
+                // NO-OP (keep the connection open)
+            }
+
+            @Override
+            public void onException(HttpServerExchange exchange, Sender sender, IOException exception) {
+                log.error("Error sending event", exception.getMessage());
+                log.debug("Exception", exception);
+            }
+        });
+    }
+
+    // TODO optionally recieve database name to backup, otherwise backup all
+    // databases.
+    /**
+     * Expecting exchange to contain the root backup url in minio
+     */
+
+    public ExecutionResponse execute(final HttpServerExchange exchange, final ServerSecurityUser user) {
+
+        var anyRequiredRoles = List.of(ServerAdminRole.BACKUP_DATABASE,
+                ServerAdminRole.ALL);
+        if (httpServer.getServer().getSecurity().checkUserHasAnyServerAdminRole(user,
+                anyRequiredRoles)) {
+            checkServerIsLeaderIfInHA();
+        }
+
+        exchange.getResponseHeaders().put(Headers.CONTENT_TYPE, "text/event-stream");
+
+        // Start a new thread to handle SSE
+        new Thread(() -> {
+            backupDatabases(exchange);
+        }).start();
+
+        return null;
+    }
+
+    private void backupDatabases(final HttpServerExchange exchange) {
+        var databaseNames = httpServer.getServer().getDatabaseNames();
+        int counter = 1;
+        long ellapsedCounter = 0l;
+        for (String databaseName : databaseNames) {
+            var database = httpServer.getServer().getDatabase(databaseName);
+            if (database.getSchema().getEmbedded().shouldBackup()) {
+                try {
+                    backupDatabase(database, counter, databaseNames.size(), exchange);
+
+                } catch (Exception e) {
+                    String event = String.format("ERROR - error backing up database %s, message: %s",
+                            databaseName, e.getMessage());
+                    sendEvent(exchange, event);
+                }
+            } else {
+                String event = String.format("INFO - (%n/$n) Skipping disabled backup of: %s", counter,
+                        databaseNames.size(), database.getName());
+                sendEvent(exchange, event);
+            }
+        }
+
+        String ellapsed = formatDuration(Duration.ofMillis(ellapsedCounter));
+        String event = String.format("INFO - Arcade backup complete. %s databases backed up in %s",
+                databaseNames.size(), ellapsed);
+        sendEvent(exchange, event);
+        exchange.getResponseSender().close();
+    }
+
+    private void backupDatabase(Database database, int counter, int numDatabases, final HttpServerExchange exchange) {
+
+        Instant dbStart = Instant.now();
+
+        String event = String.format("INFO - (%n/$n) Starting backup of: %s", counter,
+                numDatabases, database.getName());
+        sendEvent(exchange, event);
+
+        final DateFormat dateFormat = new SimpleDateFormat("yyyyMMdd-HHmmssSSS");
+        String fileName = String.format("%s-backup-%s.zip", database.getName(),
+                dateFormat.format(System.currentTimeMillis()));
+
+        String command = String.format("backup database file://%s", fileName);
+        database.command("sql", command, httpServer.getServer().getConfiguration(), new HashMap<>());
+
+        MinioRestClient.uploadBackup(database.getName(), fileName);
+
+        Instant dbStop = Instant.now();
+        String ellapsed = formatDuration(Duration.ofMillis(dbStop.toEpochMilli() - dbStart.toEpochMilli()));
+        event = String.format("INFO - (%n/$n) backup of %s completed in %s", counter,
+                numDatabases, database.getName(), ellapsed);
+        sendEvent(exchange, ellapsed);
+    }
+
+    private void checkServerIsLeaderIfInHA() {
+        final HAServer ha = httpServer.getServer().getHA();
+        if (ha != null && !ha.isLeader())
+            // NOT THE LEADER
+            throw new ServerIsNotTheLeaderException("Backup of database can be executed only on the leader server",
+                    ha.getLeaderName());
+    }
+
+    /**
+     * Format duration as HH:MM:SS for better readability compared to a million seconds
+     * @param duration
+     * @return
+     */
+    private String formatDuration(Duration duration) {
+        long HH = duration.toHours();
+        long MM = duration.toMinutesPart();
+        long SS = duration.toSecondsPart();
+        return String.format("%02d:%02d:%02d", HH, MM, SS);
+    }
+}

--- a/server/src/main/java/com/arcadedb/server/http/handler/PostBackupHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/PostBackupHandler.java
@@ -8,8 +8,10 @@ import java.time.Instant;
 import java.util.HashMap;
 import java.util.List;
 
+import com.arcadedb.GlobalConfiguration;
 import com.arcadedb.database.Database;
 import com.arcadedb.network.binary.ServerIsNotTheLeaderException;
+import com.arcadedb.serializer.json.JSONObject;
 import com.arcadedb.server.MinioRestClient;
 import com.arcadedb.server.ha.HAServer;
 import com.arcadedb.server.http.HttpServer;
@@ -18,22 +20,97 @@ import com.arcadedb.server.security.oidc.role.ServerAdminRole;
 
 import io.undertow.io.IoCallback;
 import io.undertow.io.Sender;
+import io.undertow.server.HttpHandler;
 import io.undertow.server.HttpServerExchange;
+import io.undertow.util.HeaderValues;
 import io.undertow.util.Headers;
 import lombok.extern.slf4j.Slf4j;
 
 /**
  * Backup all databases (with backups enabled) to minio
  */
+// public class PostBackupHandler extends AbstractHandler {
 @Slf4j
-public class PostBackupHandler extends AbstractHandler {
+public class PostBackupHandler implements HttpHandler {
+
+    private final HttpServer httpServer;
 
     public PostBackupHandler(final HttpServer httpServer) {
-        super(httpServer);
+        this.httpServer = httpServer;
     }
 
+    public void handleRequest(final HttpServerExchange exchange) throws Exception {
+
+        // Roles to check for when authorizing backups
+        var anyRequiredRoles = List.of(ServerAdminRole.BACKUP_DATABASE,
+                ServerAdminRole.ALL);
+
+        // Reject unauthenticated requests
+        final HeaderValues authorization = exchange.getRequestHeaders().get("Authorization");
+        if (true && (authorization == null || authorization.isEmpty())) {
+            exchange.setStatusCode(403);
+            sendErrorResponse(exchange, 403, "No authentication was provided", null, null);
+            return;
+        }
+
+        // Get user from request
+        ServerSecurityUser user = null;
+        if (authorization != null) {
+            if (GlobalConfiguration.OIDC_AUTH.getValueAsBoolean()) {
+                // TODO only allow root user basic access if JWT auth enabled
+
+                if (exchange.getRequestHeaders().get(Headers.AUTHORIZATION) != null
+                        && exchange.getRequestHeaders().get(Headers.AUTHORIZATION).toString().contains("Bearer ")) {
+
+                    String encodedJwt = exchange.getRequestHeaders().get(Headers.AUTHORIZATION).get(0);
+
+                    String decodedJwt = AbstractHandler.decodeTokenParts(encodedJwt)[1];
+                    decodedJwt = decodedJwt.replaceAll(" ", "");
+                    JSONObject json = new JSONObject(decodedJwt);
+                    String username = json.getString("preferred_username");
+                    user = httpServer.getServer().getSecurity().authenticate(username, null);
+                } else {
+                    exchange.setStatusCode(403);
+                    sendErrorResponse(exchange, 403, "Invalid authentication was provided", null, null);
+                }
+            }
+        }
+
+        // Check user has required roles
+        if (!httpServer.getServer().getSecurity().checkUserHasAnyServerAdminRole(user,
+                anyRequiredRoles)) {
+            exchange.setStatusCode(401);
+            exchange.getResponseSender().send("Unauthorized to backup databases");
+            return;
+        }
+
+        checkServerIsLeaderIfInHA();
+
+        // Set header for sending SSEs back to client
+        exchange.getResponseHeaders().put(Headers.CONTENT_TYPE, "text/event-stream");
+
+        exchange.dispatch(() -> {
+            try {
+                backupDatabases(exchange);
+            } catch (Exception e) {
+                log.error("Error backing up databases", e.getMessage());
+                log.debug("Exception", e);
+            }
+        });
+    }
+
+    /**
+     * Send an event to the client over SSE, formatted for severity and timestamp
+     */
     private void sendEvent(final HttpServerExchange exchange, String message) {
-        exchange.getResponseSender().send(message + "\n\n", new IoCallback() {
+        if (message.contains("INFO")) {
+            log.info(message);
+        } else {
+            log.error(message);
+        }
+
+        var enhancedMessage = String.format("%s %s\n", Instant.now().toString(), message);
+        exchange.getResponseSender().send(enhancedMessage, new IoCallback() {
             @Override
             public void onComplete(HttpServerExchange exchange, Sender sender) {
                 // NO-OP (keep the connection open)
@@ -47,65 +124,51 @@ public class PostBackupHandler extends AbstractHandler {
         });
     }
 
-    // TODO optionally recieve database name to backup, otherwise backup all
-    // databases.
-    /**
-     * Expecting exchange to contain the root backup url in minio
-     */
-
-    public ExecutionResponse execute(final HttpServerExchange exchange, final ServerSecurityUser user) {
-
-        var anyRequiredRoles = List.of(ServerAdminRole.BACKUP_DATABASE,
-                ServerAdminRole.ALL);
-        if (httpServer.getServer().getSecurity().checkUserHasAnyServerAdminRole(user,
-                anyRequiredRoles)) {
-            checkServerIsLeaderIfInHA();
-        }
-
-        exchange.getResponseHeaders().put(Headers.CONTENT_TYPE, "text/event-stream");
-
-        // Start a new thread to handle SSE
-        new Thread(() -> {
-            backupDatabases(exchange);
-        }).start();
-
-        return null;
-    }
-
     private void backupDatabases(final HttpServerExchange exchange) {
         var databaseNames = httpServer.getServer().getDatabaseNames();
+
         int counter = 1;
-        long ellapsedCounter = 0l;
+        int successCounter = 0;
+        int failureCounter = 0;
+        int skippedCounter = 0;
+        Instant start = Instant.now();
+
         for (String databaseName : databaseNames) {
             var database = httpServer.getServer().getDatabase(databaseName);
             if (database.getSchema().getEmbedded().shouldBackup()) {
                 try {
                     backupDatabase(database, counter, databaseNames.size(), exchange);
+                    successCounter++;
 
                 } catch (Exception e) {
-                    String event = String.format("ERROR - error backing up database %s, message: %s",
-                            databaseName, e.getMessage());
+                    failureCounter++;
+                    String event = String.format("ERROR - (%d/%d) Error backing up database %s, message: %s",
+                            counter, databaseNames.size(), databaseName, e.getMessage());
                     sendEvent(exchange, event);
+                    log.error("Error backing up database", e.getMessage());
+                    log.debug("Exception", e);
                 }
             } else {
-                String event = String.format("INFO - (%n/$n) Skipping disabled backup of: %s", counter,
+                skippedCounter++;
+                String event = String.format("INFO - (%d/%d) Skipping disabled backup of: %s", counter,
                         databaseNames.size(), database.getName());
                 sendEvent(exchange, event);
             }
+            counter++;
         }
 
-        String ellapsed = formatDuration(Duration.ofMillis(ellapsedCounter));
-        String event = String.format("INFO - Arcade backup complete. %s databases backed up in %s",
-                databaseNames.size(), ellapsed);
+        String ellapsed = formatDuration(Duration.ofMillis(Instant.now().toEpochMilli() - start.toEpochMilli()));
+        String event = String.format(
+                "INFO - Arcade backup complete. %d databases backed up in %s. %d skipped, %d failed",
+                successCounter, ellapsed, skippedCounter, failureCounter);
         sendEvent(exchange, event);
         exchange.getResponseSender().close();
     }
 
     private void backupDatabase(Database database, int counter, int numDatabases, final HttpServerExchange exchange) {
-
         Instant dbStart = Instant.now();
 
-        String event = String.format("INFO - (%n/$n) Starting backup of: %s", counter,
+        String event = String.format("INFO - (%d/%d) Starting backup of database: %s", counter,
                 numDatabases, database.getName());
         sendEvent(exchange, event);
 
@@ -113,16 +176,19 @@ public class PostBackupHandler extends AbstractHandler {
         String fileName = String.format("%s-backup-%s.zip", database.getName(),
                 dateFormat.format(System.currentTimeMillis()));
 
+        // Construct and execute the arcade sql command to backup the database to a local file.
         String command = String.format("backup database file://%s", fileName);
         database.command("sql", command, httpServer.getServer().getConfiguration(), new HashMap<>());
 
         MinioRestClient.uploadBackup(database.getName(), fileName);
 
+        // TODO delete local backup file, or clean up old backups periodically?
+
         Instant dbStop = Instant.now();
         String ellapsed = formatDuration(Duration.ofMillis(dbStop.toEpochMilli() - dbStart.toEpochMilli()));
-        event = String.format("INFO - (%n/$n) backup of %s completed in %s", counter,
+        event = String.format("INFO - (%d/%d) Backup of database %s completed in %s", counter,
                 numDatabases, database.getName(), ellapsed);
-        sendEvent(exchange, ellapsed);
+        sendEvent(exchange, event);
     }
 
     private void checkServerIsLeaderIfInHA() {
@@ -134,14 +200,18 @@ public class PostBackupHandler extends AbstractHandler {
     }
 
     /**
-     * Format duration as HH:MM:SS for better readability compared to a million seconds
-     * @param duration
-     * @return
+     * Format ellapsed time as HH:MM:SS for easier readibility
      */
     private String formatDuration(Duration duration) {
         long HH = duration.toHours();
         long MM = duration.toMinutesPart();
         long SS = duration.toSecondsPart();
         return String.format("%02d:%02d:%02d", HH, MM, SS);
+    }
+
+    private void sendErrorResponse(final HttpServerExchange exchange, final int code, final String errorMessage, final Throwable e, final String exceptionArgs) {
+        if (!exchange.isResponseStarted())
+            exchange.setStatusCode(code);
+        exchange.getResponseSender().send(errorMessage);
     }
 }

--- a/server/src/main/java/com/arcadedb/server/http/handler/PostBackupHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/PostBackupHandler.java
@@ -58,11 +58,11 @@ public class PostBackupHandler implements HttpHandler {
             if (GlobalConfiguration.OIDC_AUTH.getValueAsBoolean()) {
                 // TODO only allow root user basic access if JWT auth enabled
 
-                if (exchange.getRequestHeaders().get(Headers.AUTHORIZATION) != null
-                        && exchange.getRequestHeaders().get(Headers.AUTHORIZATION).toString().contains("Bearer ")) {
+                HeaderValues authHeader = exchange.getRequestHeaders().get(Headers.AUTHORIZATION);
 
-                    String encodedJwt = exchange.getRequestHeaders().get(Headers.AUTHORIZATION).get(0);
+                if (authHeader != null && authHeader.toString().contains("Bearer ")) {
 
+                    String encodedJwt = authHeader.get(0);
                     String decodedJwt = AbstractHandler.decodeTokenParts(encodedJwt)[1];
                     decodedJwt = decodedJwt.replaceAll(" ", "");
                     JSONObject json = new JSONObject(decodedJwt);
@@ -102,6 +102,8 @@ public class PostBackupHandler implements HttpHandler {
      * Send an event to the client over SSE, formatted for severity and timestamp
      */
     private void sendEvent(final HttpServerExchange exchange, String message) {
+
+        // Log message to container
         if (message.contains("INFO")) {
             log.info(message);
         } else {
@@ -175,7 +177,8 @@ public class PostBackupHandler implements HttpHandler {
         String fileName = String.format("%s-backup-%s.zip", database.getName(),
                 dateFormat.format(System.currentTimeMillis()));
 
-        // Construct and execute the arcade sql command to backup the database to a local file.
+        // Construct and execute the arcade sql command to backup the database to a
+        // local file.
         String command = String.format("backup database file://%s", fileName);
         database.command("sql", command, httpServer.getServer().getConfiguration(), new HashMap<>());
 
@@ -208,7 +211,8 @@ public class PostBackupHandler implements HttpHandler {
         return String.format("%02d:%02d:%02d", HH, MM, SS);
     }
 
-    private void sendErrorResponse(final HttpServerExchange exchange, final int code, final String errorMessage, final Throwable e, final String exceptionArgs) {
+    private void sendErrorResponse(final HttpServerExchange exchange, final int code, final String errorMessage,
+            final Throwable e, final String exceptionArgs) {
         if (!exchange.isResponseStarted())
             exchange.setStatusCode(code);
         exchange.getResponseSender().send(errorMessage);

--- a/server/src/main/java/com/arcadedb/server/http/handler/PostBackupHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/PostBackupHandler.java
@@ -29,7 +29,6 @@ import lombok.extern.slf4j.Slf4j;
 /**
  * Backup all databases (with backups enabled) to minio
  */
-// public class PostBackupHandler extends AbstractHandler {
 @Slf4j
 public class PostBackupHandler implements HttpHandler {
 

--- a/server/src/main/java/com/arcadedb/server/http/handler/PostServerCommandHandler.java
+++ b/server/src/main/java/com/arcadedb/server/http/handler/PostServerCommandHandler.java
@@ -50,8 +50,6 @@ import com.nimbusds.oauth2.sdk.util.StringUtils;
 import io.undertow.server.HttpServerExchange;
 
 import java.io.*;
-import java.nio.charset.StandardCharsets;
-import java.rmi.*;
 import java.util.*;
 
 public class PostServerCommandHandler extends AbstractHandler {

--- a/server/src/main/java/com/arcadedb/server/security/ServerSecurityUser.java
+++ b/server/src/main/java/com/arcadedb/server/security/ServerSecurityUser.java
@@ -60,6 +60,11 @@ public class ServerSecurityUser implements SecurityUser {
       final JSONObject userDatabases = userConfiguration.getJSONObject("databases");
       databasesNames = Collections.unmodifiableSet(userDatabases.keySet());
 
+      if (databasesNames.contains(ArcadeRole.ALL_WILDCARD)) {
+        // User has some level of access to all databases
+        databasesNames = Collections.unmodifiableSet(server.getDatabaseNames());
+      }
+
     } else {
       databasesNames = Collections.emptySet();
     }

--- a/server/src/main/java/com/arcadedb/server/security/oidc/role/ServerAdminRole.java
+++ b/server/src/main/java/com/arcadedb/server/security/oidc/role/ServerAdminRole.java
@@ -10,6 +10,7 @@ import lombok.Getter;
 public enum ServerAdminRole {
     CREATE_DATABASE(Constants.CREATE_DATABASE, Constants.CREATE_DATABASE),
     DROP_DATABASE(Constants.DROP_DATABASE, Constants.DROP_DATABASE),
+    BACKUP_DATABASE(Constants.BACKUP_DATABASE, Constants.BACKUP_DATABASE),
     ALL(Constants.ALL, Constants.ALL);
 
     @Getter
@@ -39,6 +40,7 @@ public enum ServerAdminRole {
     public static class Constants {
         public static final String CREATE_DATABASE = "createDatabase";
         public static final String DROP_DATABASE = "dropDatabase";
+        public static final String BACKUP_DATABASE = "backupDatabase";
         public static final String ALL = "*";
     }
 }

--- a/server/src/main/resources/static/index.html
+++ b/server/src/main/resources/static/index.html
@@ -280,7 +280,6 @@
         ) {
           showLoginPopup();
         } else {
-          console.log("index gc", globalCredentials);
           $("#loginSpinner").show();
           if (globalCredentials != null) {
             updateDatabases(function () {


### PR DESCRIPTION
## What does this PR do?
1. Adds a REST hook to trigger backups to MinIO
2. Stream SSEs back to the calling client to keep them up to date with any progress.

## Motivation
Current DF backup design uses Velero to backup up the internal MinIO to S3 or an external object store. We therefore need to backup our datastores to MinIO.

## Related issues
Relates to #2449

## Setup

1. Switch to DF PR branch locally https://github.com/raft-tech/data-fabric/pull/2494
2. Deploy Df

```
./hacks/df_create_kind.sh
export GHP_USERNAME=your_github_username_goes_here
export GHP_SECRET=your_github_pat_goes_here
./hacks/df_deploy.sh
```

3. Build arcade locally

```
 docker buildx build --platform linux/arm64 --load -t raft-tech/arcadedev ./
```

4. load into kind

```
 kind load docker-image raft-tech/arcadedev  --name data-fabric
 ```

5. Update image in arcade's replicaset

6. Kill the pod to force it to update if needed

Follow instructions in DF PR to exercise cron job